### PR TITLE
MAINT: Convert most references to bibtex.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,9 @@ repos:
   hooks:
   - id: black
 
-- repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: 'v0.11.7'
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.11.7
   hooks:
+    # Run the linter.
     - id: ruff
       args: [--fix]

--- a/docs/source/bibliography.md
+++ b/docs/source/bibliography.md
@@ -12,19 +12,19 @@ order:
 - Vallado, David A., and Wayne D. McClain. *Fundamentals of
   astrodynamics and applications*. Vol. 12. Springer Science &
   Business Media, 2001.
-  ({cite:t}`2001:vallado`)
+  {cite:p}`Vallado2001`
 - Curtis, Howard. *Orbital mechanics for engineering students*.
-  Butterworth-Heinemann, 2013.
+  Butterworth-Heinemann, 2013 {cite:p}`Curtis2013`.
 - Bate, Roger R., Donald D. Mueller, William W. Saylor, and Jerry E.
   White. *Fundamentals of astrodynamics: (dover books on physics)*.
-  Dover publications, 2013.
+  Dover publications, 2013. {cite:p}`Bate_et_al2020`
 - Battin, Richard H. *An introduction to the mathematics and methods
-  of astrodynamics*. Aiaa, 1999.
+  of astrodynamics*. Aiaa, 1999. {cite:p}`Battin1999`
 - Edelbaum, Theodore N. \"Propulsion requirements for controllable
-  satellites.\" *ARS Journal* 31, no. 8 (1961): 1079-1089.
+  satellites.\" *ARS Journal* 31, no. 8 (1961): 1079-1089. {cite:p}`Edelbaum1961`
 - Walker, M. J. H., B. Ireland, and Joyce Owens. \"A set modified
   equinoctial orbit elements.\" *Celestial Mechanics* 36.4 (1985):
-  409-419.
+  409-419. {cite:p}`Walker1985`
 
 ```{bibliography} boinor.bib
 :all:

--- a/docs/source/boinor.bib
+++ b/docs/source/boinor.bib
@@ -1,24 +1,109 @@
-@Book{1987:nelson,
-  author = {Edward Nelson},
-  title = {Radically Elementary Probability Theory},
-  publisher = {Princeton University Press},
-  year = {1987}
+@Book{Bate_et_al2020,
+  author       = {Bate, Roger R. and Donald D. Mueller and Jerry E.  White and
+                  William W. Saylor},
+  title        = {Fundamentals of astrodynamics},
+  year         = 2020,
+  publisher    = {Dover Publications Inc},
+  edition      = {2nd},
+  isbn         = 9780486497044
 }
 
-@Book{2001:vallado,
-  author = {David A. Vallado and Wayne D. McClain},
-  title = {Fundamentals of astrodynamics and applications},
-  volume = {12},
-  publisher = { Springer Science & Business Media},
-  year = {2001},
-  edition = {4}
+@Article{Farnocchia2013,
+  author       = {Farnocchia, Davide and Cioci, Davide Bracali and Milani,
+                  Andrea},
+  title        = {Robust resolution of Kepler’s equation in all eccentricity
+                  regimes},
+  journal      = {Celestial Mechanics and Dynamical Astronomy},
+  year         = 2013,
+  volume       = 116,
+  number       = 1,
+  pages        = {21--34},
+  month        = feb,
+  ISSN         = {1572-9478},
+  doi          = {10.1007/s10569-013-9476-9},
+  publisher    = {Springer Science and Business Media LLC}
 }
 
-@Book{2001:notmentioned,
-  author = {not mentioned},
-  title = {Fundamentals of astrodynamics and applications},
-  volume = {12},
-  publisher = { Springer Science & Business Media},
-  year = {2001},
-  edition = {4}
+@Article{Walker1985,
+  author       = {Walker, M. J. H. and Ireland, B. and Owens, Joyce},
+  title        = {A set modified equinoctial orbit elements},
+  journal      = {Celestial Mechanics},
+  year         = 1985,
+  volume       = 36,
+  number       = 4,
+  pages        = {409–419},
+  month        = aug,
+  ISSN         = {1572-9478},
+  doi          = {10.1007/bf01227493},
+  publisher    = {Springer Science and Business Media LLC}
+}
+
+@Article{Edelbaum1961,
+  author       = {Edelbaum, Theodore N.},
+  title        = {Propulsion Requirements for Controllable Satellites},
+  journal      = {ARS Journal},
+  year         = 1961,
+  volume       = 31,
+  number       = 8,
+  pages        = {1079–1089},
+  month        = aug,
+  ISSN         = {1936-9972},
+  doi          = {10.2514/8.5723},
+  publisher    = {American Institute of Aeronautics and Astronautics (AIAA)}
+}
+
+
+@Article{Kechichian1997,
+  author       = {Kechichian, Jean Albert},
+  title        = {Reformulation of Edelbaum’s Low-Thrust Transfer Problem Using
+                  Optimal Control Theory},
+  journal      = {Journal of Guidance, Control, and Dynamics},
+  year         = 1997,
+  volume       = 20,
+  number       = 5,
+  pages        = {988–994},
+  month        = sep,
+  ISSN         = {1533-3884},
+  DOI          = {10.2514/2.4145},
+  publisher    = {American Institute of Aeronautics and Astronautics (AIAA)}
+}
+
+@Misc{IAU_IV_GA_1938,
+  author       = {IAU VIth General Assembly},
+  year         = 1938
+}
+
+@Book{Battin1999,
+  author       = {Battin, Richard H.},
+  title        = {An Introduction to the Mathematics and Methods of
+                  Astrodynamics, Revised Edition},
+  year         = 1999,
+  publisher    = {American Institute of Aeronautics and Astronautics, Inc.},
+  month        = jan,
+  isbn         = 9781600861543,
+  doi          = {10.2514/4.861543}
+}
+
+@Book{Curtis2013,
+  author       = {Curtis, Howard},
+  title        = {Orbital mechanics for engineering students},
+  year         = 2013,
+  publisher    = {Butterworth-Heinemann}
+}
+
+@Book{Vallado2001,
+  author       = {David A. Vallado and Wayne D. McClain},
+  title        = {Fundamentals of astrodynamics and applications},
+  year         = 2001,
+  publisher    = {Springer Science & Business Media},
+  volume       = 12,
+  edition      = {4th}
+}
+
+@Book{Vallado2013,
+  author       = {David A. Vallado},
+  title        = {Fundamentals of Astrodynamics and Applications},
+  year         = 2013,
+  publisher    = {Microcosm Press},
+  edition      = {4th}
 }

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -28,7 +28,7 @@ For example, if you have the position and velocity vectors you can use
 {py:meth}`~boinor.twobody.orbit.scalar.Orbit.from_vectors`:
 
 ```python
-# Data from Curtis, example 4.3
+# Data from Curtis (2013), example 4.3
 r = [-6045, -3490, 2500] << u.km
 v = [-3.457, 6.618, 2.533] << u.km / u.s
 
@@ -258,7 +258,7 @@ directly in this way. For instance, to examine the effect of J2 perturbation:
 >>> final = initial.propagate(tofs, method=CowellPropagator(f=f))
 ```
 
-The J2 perturbation changes the orbit parameters (from Curtis example 12.2):
+The J2 perturbation changes the orbit parameters {cite:p}`Curtis2013{example 12.2}`:
 
 ```python
 >>> ((final.raan - initial.raan) / tofs).to(u.deg / u.h)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,12 +133,13 @@ exclude = [
 [tool.black]
 line-length = 79
 
-[tool.ruff]
-select = [
-    "E",  # pycodestyle, see https://github.com/charliermarsh/ruff#pycodestyle-e-w
-#    "D",  # pydocstyle, see https://github.com/charliermarsh/ruff#pydocstyle-d
-    "F",  # pyflakes, see https://github.com/charliermarsh/ruff#pyflakes-f
-    "I"   # isort, see https://github.com/charliermarsh/ruff#isort-i
+[tool.ruff.lint]
+extend-select = [
+    "E",  # pycodestyle, see https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
+#    "D",  # pydocstyle, see https://docs.astral.sh/ruff/rules/#pydocstyle-d
+    "F",  # pyflakes, see https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "I",   # isort, see https://docs.astral.sh/ruff/rules/#isort-i
+    "NPY201", "NPY003",
 ]
 
 ignore = [
@@ -153,16 +154,13 @@ exclude = [
     "dist",
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 combine-as-imports = true
 force-sort-within-sections = true
 known-first-party = ["boinor"]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 18
-
-[tool.ruff.lint]
-select = ["NPY201"]
 
 [tool.mypy]
 check_untyped_defs = true

--- a/src/boinor/_math/special.py
+++ b/src/boinor/_math/special.py
@@ -6,7 +6,7 @@ import numpy as np
 
 @jit
 def hyp2f1b(x):
-    """Hypergeometric function 2F1(3, 1, 5/2, x), see [Battin].
+    """Hypergeometric function 2F1(3, 1, 5/2, x), see :cite:t:`Battin1999`.
 
     .. todo::
         Add more information about this function

--- a/src/boinor/core/angles.py
+++ b/src/boinor/core/angles.py
@@ -62,7 +62,7 @@ def D_to_nu(D):
 
     Notes
     -----
-    From [1]_:
+    From :cite:t:`Farnocchia2013`:
 
     .. math::
 
@@ -96,28 +96,17 @@ def nu_to_D(nu):
     -----
     The treatment of the parabolic case is heterogeneous in the literature,
     and that includes the use of an equivalent quantity to the eccentric anomaly:
-    [1]_ calls it "parabolic eccentric anomaly" D,
-    [2]_ also uses the letter D but calls it just "parabolic anomaly",
-    [3]_ uses the letter B citing indirectly [4]_
+    :cite:t:`Farnocchia2013` calls it "parabolic eccentric anomaly" D,
+    :cite:t:`Bate_et_al2020` also uses the letter D but calls it just "parabolic anomaly",
+    :cite:p:`Vallado2013` uses the letter B citing indirectly :cite:t:`IAU_IV_GA_1938`
     (which however calls it "parabolic time argument"),
-    and [5]_ does not bother to define it.
+    and :cite:t:`Battin1999` does not bother to define it.
 
     We use this definition:
 
     .. math::
 
         B = \tan{\frac{\nu}{2}}
-
-    References
-    ----------
-    .. [1] Farnocchia, Davide, Davide Bracali Cioci, and Andrea Milani.
-       "Robust resolution of Kepler’s equation in all eccentricity regimes."
-    .. [2] Bate, Muller, White.
-    .. [3] Vallado, David. "Fundamentals of Astrodynamics and Applications",
-       2013.
-    .. [4] IAU VIth General Assembly, 1938.
-    .. [5] Battin, Richard H. "An introduction to the Mathematics and Methods
-       of Astrodynamics, Revised Edition", 1999.
 
     """
     # TODO: Rename to B
@@ -149,7 +138,7 @@ def nu_to_E(nu, ecc):
 
     Notes
     -----
-    The implementation uses the half-angle formula from [3]_:
+    The implementation uses the half-angle formula from :cite:t:`Vallado2013`:
 
     .. math::
         E = 2 \arctan \left ( \sqrt{\frac{1 - e}{1 + e}} \tan{\frac{\nu}{2}} \right)
@@ -186,7 +175,7 @@ def nu_to_F(nu, ecc):
 
     Notes
     -----
-    The implementation uses the half-angle formula from [3]_:
+    The implementation uses the half-angle formula from :cite:t:`Vallado2013`:
 
     .. math::
         F = 2 \operatorname{arctanh} \left( \sqrt{\frac{e-1}{e+1}} \tan{\frac{\nu}{2}} \right)
@@ -221,7 +210,7 @@ def E_to_nu(E, ecc):
 
     Notes
     -----
-    The implementation uses the half-angle formula from [3]_:
+    The implementation uses the half-angle formula from :cite:t:`Vallado2013`:
 
     .. math::
         \nu = 2 \arctan \left( \sqrt{\frac{1 + e}{1 - e}} \tan{\frac{E}{2}} \right)
@@ -250,7 +239,7 @@ def F_to_nu(F, ecc):
 
     Notes
     -----
-    The implementation uses the half-angle formula from [3]_:
+    The implementation uses the half-angle formula from :cite:t:`Vallado2013`:
 
     .. math::
         \nu = 2 \arctan \left( \sqrt{\frac{e + 1}{e - 1}} \tanh{\frac{F}{2}} \right)
@@ -334,7 +323,7 @@ def M_to_D(M):
 
     Notes
     -----
-    This uses the analytical solution of Barker's equation from [5]_.
+    This uses the analytical solution of Barker's equation from :cite:t:`Battin1999`.
 
     """
     B = 3.0 * M / 2.0
@@ -397,7 +386,7 @@ def F_to_M(F, ecc):
 
     Notes
     -----
-    As noted in [5]_, by manipulating
+    As noted in :cite:t:`Battin1999`, by manipulating
     the parametric equations of the hyperbola
     we can derive a quantity that is equivalent
     to the mean anomaly in the elliptic case:
@@ -462,7 +451,7 @@ def fp_angle(nu, ecc):
 
     Notes
     -----
-    From [3]_, pp. 113:
+    From :cite:t:`Vallado2013`, pp. 113:
 
     .. math::
 

--- a/src/boinor/core/elements.py
+++ b/src/boinor/core/elements.py
@@ -78,8 +78,8 @@ def rv_pqw(k, p, ecc, nu):
 
     Notes
     -----
-    These formulas can be checked at Curtis 3rd. Edition, page 110. Also the
-    example proposed is 2.11 of Curtis 3rd Edition book.
+    These formulas can be checked at :cite:t:`Curtis2013`, 3rd Edition, page 110. Also the
+    example proposed is 2.11 of :cite:t:`Curtis2013`, 3rd Edition book.
 
     .. math::
 
@@ -208,7 +208,7 @@ def coe2rv_many(k, p, ecc, inc, raan, argp, nu):
 def coe2mee(p, ecc, inc, raan, argp, nu):
     r"""Converts from classical orbital elements to modified equinoctial orbital elements.
 
-    The definition of the modified equinoctial orbital elements is taken from [Walker, 1985].
+    The definition of the modified equinoctial orbital elements is taken from :cite:t:`Walker1985`.
 
     The modified equinoctial orbital elements are a set of orbital elements that are useful for
     trajectory analysis and optimization. They are valid for circular, elliptic, and hyperbolic
@@ -308,8 +308,7 @@ def rv2coe(k, r, v, tol=1e-8):
 
     Notes
     -----
-    This example is a real exercise from Orbital Mechanics for Engineering
-    students by Howard D.Curtis. This exercise is 4.3 of 3rd. Edition, page 200.
+    This example is a real exercise from :cite:t:`Curtis2013`, 3rd Edition, exercise is 4.3, page 200.
 
     1. First the angular momentum is computed:
 
@@ -432,7 +431,7 @@ def mee2coe(p, f, g, h, k, L):
     orbital elements.
 
     The definition of the modified equinoctial orbital elements is taken from
-    [Walker, 1985].
+    :cite:t:`Walker1985`.
 
     .. math::
 

--- a/src/boinor/core/iod.py
+++ b/src/boinor/core/iod.py
@@ -96,16 +96,16 @@ def vallado(k, r0, r, tof, M, prograde, lowpath, numiter, rtol):
 
     Notes
     -----
-    This procedure can be found in section 5.3 of Curtis, with all the
+    This procedure can be found in section 5.3 of :cite:t:`Curtis2013`, with all the
     theoretical description of the problem. Analytical example can be found
     in the same book under name Example 5.2.
 
     """
     # TODO: expand for the multi-revolution case.
-    # Issue: https://github.com/boinor/boinor/issues/858
+    # Issue: https://github.com/poliastro/poliastro/issues/858
     if M > 0:
         raise NotImplementedError(
-            "Multi-revolution scenario not supported for Vallado. See issue https://github.com/boinor/boinor/issues/858"
+            "Multi-revolution scenario not supported for Vallado. See issue https://github.com/poliastro/poliastro/issues/858"
         )
 
     t_m = 1 if prograde else -1

--- a/src/boinor/core/maneuver.py
+++ b/src/boinor/core/maneuver.py
@@ -168,16 +168,15 @@ def correct_pericenter(k, R, J2, max_delta_r, v, a, inc, ecc):
 
     Notes
     -----
-    The algorithm was obtained from "Fundamentals of Astrodynamics and Applications, 4th ed (2013)" by David A.
-    Vallado, page 885.
-    Given a max_delta_r, we determine the maximum perigee drift before we do an orbit-adjustment burn
+    The algorithm was obtained from :cite:t:`Vallado2013`, page 885.
+    Given a ``max_delta_r``, we determine the maximum perigee drift before we do an orbit-adjustment burn
     to restore the perigee to its nominal value. We estimate the time until this burn using the allowable drift
     delta_w and the drift rate :math:`|dw|`.
-    For positive delta_v, the change in the eccentricity is positive for perigee burns and negative for apogee burns.
-    The opposite holds for a delta_v applied against the velocity vector, which decreases the satellite’s velocity.
+    For positive ``delta_v``, the change in the eccentricity is positive for perigee burns and negative for apogee burns.
+    The opposite holds for a ``delta_v`` applied against the velocity vector, which decreases the satellite’s velocity.
     Perigee drift are mainly due to the zonal harmonics, which cause variations in the altitude by changing the
     argument of perigee.
-    Please note that ecc ≈ 0.001, so the error incurred by assuming a small eccentricity is on the order of 0.1%.
+    Please note that ``ecc`` ≈ 0.001, so the error incurred by assuming a small eccentricity is on the order of 0.1%.
     This is smaller than typical variations in thruster performance between burns.
 
     """

--- a/src/boinor/core/perturbations.py
+++ b/src/boinor/core/perturbations.py
@@ -31,7 +31,7 @@ def J2_perturbation(t0, state, k, J2, R):
     Notes
     -----
     The J2 accounts for the oblateness of the attractor. The formula is given in
-    Howard Curtis, (12.30)
+    :cite:t:`Curtis2013{Eq. 12.30}`.
 
     """
     r_vec = state[:3]
@@ -65,8 +65,8 @@ def J3_perturbation(t0, state, k, J3, R):
     Notes
     -----
     The J3 accounts for the oblateness of the attractor. The formula is given in
-    Howard Curtis, problem 12.8
-    This perturbation has not been fully validated, see https://github.com/boinor/boinor/pull/398
+    :cite:t:`Curtis2013`, problem 12.8
+    This perturbation has not been fully validated, see https://github.com/poliastro/poliastro/pull/398
 
     """
     r_vec = state[:3]
@@ -114,8 +114,8 @@ def atmospheric_drag_exponential(t0, state, k, R, C_D, A_over_m, H0, rho0):
     -----
     This function provides the acceleration due to atmospheric drag
     using an overly-simplistic exponential atmosphere model. We follow
-    Howard Curtis, section 12.4
-    the atmospheric density model is rho(H) = rho0 x exp(-H / H0)
+    :cite:t:`Curtis2013`, section 12.4
+    the atmospheric density model is ``rho(H) = rho0 * exp(-H / H0)``
 
     """
     H = norm(state[:3])
@@ -189,7 +189,7 @@ def third_body(t0, state, k, k_third, perturbation_body):
 
     Notes
     -----
-    This formula is taken from Howard Curtis, section 12.10. As an example, a third body could be
+    This formula is taken from :cite:t:`Curtis2013`, section 12.10. As an example, a third body could be
     the gravity from the Moon acting on a small satellite.
 
     """
@@ -231,7 +231,7 @@ def radiation_pressure(t0, state, k, R, C_R, A_over_m, Wdivc_s, star):
     Notes
     -----
     This function provides the acceleration due to star light pressure. We follow
-    Howard Curtis, section 12.9
+    :cite:t:`Curtis2013`, section 12.9
 
     """
     r_star = star(t0)

--- a/src/boinor/core/propagation/vallado.py
+++ b/src/boinor/core/propagation/vallado.py
@@ -67,7 +67,7 @@ def vallado(k, r0, v0, tof, numiter):
 
     Notes
     -----
-    The theoretical procedure is explained in section 3.7 of Curtis in really
+    The theoretical procedure is explained in section 3.7 of :cite:t:`Curtis2013` in really
     deep detail. For analytical example, check in the same book for example 3.6.
 
     """

--- a/src/boinor/core/sensors.py
+++ b/src/boinor/core/sensors.py
@@ -26,8 +26,7 @@ def min_and_max_ground_range(h, η_fov, η_center, R):
 
     Notes
     -----
-    For further information, please take a look at "Fundamentals of Astrodynamics and Applications", 4th ed (2013)"
-    by David A. Vallado, pages 853-860.
+    For further information, please take a look at :cite:t:`Vallado2013`, pages 853-860.
 
     """
     r_sat = R + h
@@ -83,8 +82,7 @@ def ground_range_diff_at_azimuth(h, η_fov, η_center, β, φ_nadir, λ_nadir, R
 
     Notes
     -----
-    For further information, please take a look at "Fundamentals of Astrodynamics and Applications", 4th ed (2013)"
-    by David A. Vallado, pages 853-860.
+    For further information, please take a look at :cite:t:`Vallado2013`, pages 853-860.
 
     """
     if not 0 <= β < np.pi:

--- a/src/boinor/core/thrust/change_a_inc.py
+++ b/src/boinor/core/thrust/change_a_inc.py
@@ -81,14 +81,8 @@ def change_a_inc(k, a_0, a_f, inc_0, inc_f, f):
 
     Notes
     -----
-    Edelbaum theory, reformulated by Kéchichian.
+    Edelbaum theory :cite:p:`Edelbaum1961`, reformulated by :cite:t:`Kechichian1997`.
 
-    References
-    ----------
-    * Edelbaum, T. N. "Propulsion Requirements for Controllable
-      Satellites", 1961.
-    * Kéchichian, J. A. "Reformulation of Edelbaum's Low-Thrust
-      Transfer Problem Using Optimal Control Theory", 1997.
     """
     V_0, _V_f, beta_0_ = compute_parameters(k, a_0, a_f, inc_0, inc_f)
 

--- a/src/boinor/earth/util.py
+++ b/src/boinor/earth/util.py
@@ -27,8 +27,7 @@ def raan_from_ltan(epoch, ltan=12.0):
     -----
     Calculations of the sun mean longitude and equation of time
     follow "Fundamentals of Astrodynamics and Applications"
-    Fourth edition by Vallado, David A.
-    (:cite:t:`2001:vallado`)
+    Fourth edition by :cite:t:`Vallado2013`.
     """
     T_UT1 = ((epoch.ut1 - constants.J2000).value / 36525.0) * u.deg
     T_TDB = ((epoch.tdb - constants.J2000).value / 36525.0) * u.deg

--- a/src/boinor/threebody/restricted.py
+++ b/src/boinor/threebody/restricted.py
@@ -17,8 +17,7 @@ def lagrange_points(r12, m1, m2):
 
     Computes the Lagrangian points of CR3BP given the distance between two
     bodies and their masses.
-    It uses the formulation found in Eq. (2.204) of Curtis, Howard. 'Orbital
-    mechanics for engineering students'. Elsevier, 3rd Edition.
+    It uses the formulation found in Eq. (2.204) of :cite:t:`Curtis2013`, 3rd Edition.
 
     Parameters
     ----------

--- a/src/boinor/twobody/angles.py
+++ b/src/boinor/twobody/angles.py
@@ -34,9 +34,7 @@ def D_to_nu(D):
 
     Notes
     -----
-    Taken from Farnocchia, Davide, Davide Bracali Cioci, and Andrea Milani.
-    "Robust resolution of Kepler’s equation in all eccentricity regimes."
-    Celestial Mechanics and Dynamical Astronomy 116, no. 1 (2013): 21-34.
+    Taken from :cite:t:`Farnocchia2013`.
     """
     return (D_to_nu_fast(D.to_value(u.rad)) * u.rad).to(D.unit)
 
@@ -57,9 +55,7 @@ def nu_to_D(nu):
 
     Notes
     -----
-    Taken from Farnocchia, Davide, Davide Bracali Cioci, and Andrea Milani.
-    "Robust resolution of Kepler’s equation in all eccentricity regimes."
-    Celestial Mechanics and Dynamical Astronomy 116, no. 1 (2013): 21-34.
+    Taken from :cite:t:`Farnocchia2013`.
     """
     return (nu_to_D_fast(nu.to_value(u.rad)) * u.rad).to(nu.unit)
 
@@ -104,7 +100,7 @@ def nu_to_F(nu, ecc):
 
     Notes
     -----
-    Taken from Curtis, H. (2013). *Orbital mechanics for engineering students*. 167
+    Taken from :cite:t:`Curtis2013{p. 167}`.
 
     """
     return (nu_to_F_fast(nu.to_value(u.rad), ecc.value) * u.rad).to(nu.unit)

--- a/src/boinor/twobody/propagation/vallado.py
+++ b/src/boinor/twobody/propagation/vallado.py
@@ -33,7 +33,7 @@ class ValladoPropagator:
     Notes
     -----
     This algorithm is based on Vallado implementation, and does basic Newton
-    iteration on the Kepler equation written using universal variables. Battin
+    iteration on the Kepler equation written using universal variables. :cite:t:`Battin1999`
     claims his algorithm uses the same amount of memory but is between 40 %
     and 85 % faster.
 

--- a/src/boinor/twobody/thrust/change_a_inc.py
+++ b/src/boinor/twobody/thrust/change_a_inc.py
@@ -31,14 +31,8 @@ def change_a_inc(k, a_0, a_f, inc_0, inc_f, f):
 
     Notes
     -----
-    Edelbaum theory, reformulated by Kéchichian.
+    Edelbaum theory :cite:p:`Edelbaum1961`, reformulated by :cite:t:`Kechichian1997`.
 
-    References
-    ----------
-    * Edelbaum, T. N. "Propulsion Requirements for Controllable
-      Satellites", 1961.
-    * Kéchichian, J. A. "Reformulation of Edelbaum's Low-Thrust
-      Transfer Problem Using Optimal Control Theory", 1997.
     """
     a_d, delta_V, t_f = change_a_inc_fast(
         k=k.to_value(u.km**3 / u.s**2),

--- a/tests/test_iod.py
+++ b/tests/test_iod.py
@@ -175,7 +175,7 @@ def test_vallado_not_implemented_multirev():
     with pytest.raises(NotImplementedError) as excinfo:
         vallado.lambert(k, r0, r, tof, M=1)
     assert (
-        "Multi-revolution scenario not supported for Vallado. See issue https://github.com/boinor/boinor/issues/858"
+        "Multi-revolution scenario not supported for Vallado. See issue https://github.com/poliastro/poliastro/issues/858"
         in excinfo.exconly()
     )
 

--- a/tests/tests_threebody/test_restricted.py
+++ b/tests/tests_threebody/test_restricted.py
@@ -8,7 +8,7 @@ from boinor.threebody.restricted import lagrange_points_vec
 
 
 def test_lagrange_points_vec():
-    # Figure 2.36 from Curtis
+    # Figure 2.36 from Curtis (2013)
 
     deg60 = 60 * pi / 180
     expected_L1 = 326400 * ([1, 0, 0] * u.km)
@@ -20,7 +20,7 @@ def test_lagrange_points_vec():
     earth_mass = Earth.mass
     moon_mass = Moon.mass
 
-    # Values from Curtis
+    # Values from Curtis (2013)
     # earth_mass = 5.974e24 * u.kg
     # moon_mass = 73.48e21 * u.kg
 

--- a/tests/tests_threebody/test_soi.py
+++ b/tests/tests_threebody/test_soi.py
@@ -27,7 +27,7 @@ from boinor.threebody.soi import hill_radius, laplace_radius
         (Uranus, 5.18e10 * u.m),
         (Neptune, 8.66e10 * u.m),
     ]
-    # Data from Table A.2., Curtis "Orbital Mechanics for Engineering Students"
+    # Data from Table A.2., Curtis (2013) "Orbital Mechanics for Engineering Students"
 )
 def test_laplace_radius(body, expected_r_SOI):
     r_SOI = laplace_radius(body)


### PR DESCRIPTION
I cannot find any edition of Bates et al. published in 2013. The second edition was published in 2020.

Perhaps @astrojuanlu knows which edition is the one from 2013.

<!-- readthedocs-preview boinor start -->
----
📚 Documentation preview 📚: https://boinor--21.org.readthedocs.build/en/21/

<!-- readthedocs-preview boinor end -->