### PR TITLE
Fix aitoff plotting init

### DIFF
--- a/docs/source/examples/aitoff.myst.md
+++ b/docs/source/examples/aitoff.myst.md
@@ -46,7 +46,7 @@ from astropy.time import Time
 import numpy as np
 
 
-from boinor.plotting.aitoff import AitoffPlotter
+from boinor.plotting import AitoffPlotter
 ```
 
 The `AitoffPlotter` class can be initialized with various options. The simplest

--- a/docs/source/gallery.md
+++ b/docs/source/gallery.md
@@ -26,5 +26,6 @@ the plotting utilities, insight on the {ref}`API <api-reference>` capabilities a
    /examples/detecting-events.myst.md
    /examples/loading-OMM-and-TLE-satellite-data.myst.md
    /examples/render-dsk-kernels.myst.md
+   /examples/aitoff.myst.md
 
 ```

--- a/src/boinor/plotting/__init__.py
+++ b/src/boinor/plotting/__init__.py
@@ -1,10 +1,12 @@
 """Sub-package related to plotting orbits"""
+from boinor.plotting.aitoff import AitoffPlotter
 from boinor.plotting.gabbard import GabbardPlotter
 from boinor.plotting.orbit.plotter import OrbitPlotter
 from boinor.plotting.porkchop import PorkchopPlotter
 from boinor.plotting.tisserand import TisserandPlotter
 
 __all__ = [
+    "AitoffPlotter",
     "OrbitPlotter",
     "GabbardPlotter",
     "PorkchopPlotter",


### PR DESCRIPTION
The website didn't show the myst.md file because it wasn't added to the gallery.md, and __init__.py didn't follow the software architecture. Fixed the documentation and architecture. Sorry, about that I missed it.

<!-- readthedocs-preview boinor start -->
----
📚 Documentation preview 📚: https://boinor--50.org.readthedocs.build/en/50/

<!-- readthedocs-preview boinor end -->