### PR TITLE
fix: allow users to overwrite Plotly layouts if passing in a figure

### DIFF
--- a/src/boinor/plotting/orbit/backends/plotly.py
+++ b/src/boinor/plotting/orbit/backends/plotly.py
@@ -265,6 +265,11 @@ class Plotly2D(BasePlotly):
             yaxis={"scaleanchor": "x"},
             template=theme,
         )
+
+        # Properly allow overloading layouts
+        if figure is not None and figure.layout is not None:
+            layout = figure.layout
+
         super().__init__(figure, layout)
 
     def draw_marker(self, position, *, color, label, marker_symbol, size):
@@ -426,6 +431,11 @@ class Plotly3D(BasePlotly):
             scene={"aspectmode": "data"},
             template=theme,
         )
+
+        # Properly allow overloading layouts
+        if figure is not None and figure.layout is not None:
+            layout = figure.layout
+
         super().__init__(figure, layout)
 
     def draw_marker(self, position, *, color, marker_symbol, label, size):


### PR DESCRIPTION
title. allows lib users to overwrite Plotly3D layouts if they pass in their own Figure

this fix allows for orthographic projection to be done easily without needing to use the developer console

```py
camera = go.layout.scene.Camera()
camera.projection = go.layout.scene.camera.Projection()
camera.projection.type = "orthographic"
scene = go.layout.Scene(camera=camera)
layout = go.Layout(scene=scene)
fig = go.Figure(layout=layout)
# or...
layout = {"scene": {"camera": {"projection": {"type": "orthographic"}}}}
fig = go.Figure(layout=layout)

op = OrbitPlotter(backend=Plotly3D(figure=fig))
```
<img width="1079" height="718" alt="image" src="https://github.com/user-attachments/assets/6e32fafd-1103-4c50-8107-72fd47bc2d45" />


<!-- readthedocs-preview boinor start -->
----
📚 Documentation preview 📚: https://boinor--57.org.readthedocs.build/en/57/

<!-- readthedocs-preview boinor end -->